### PR TITLE
Fix issue #11

### DIFF
--- a/com/itsinbox/smartbox/model/PKCS11Card.java
+++ b/com/itsinbox/smartbox/model/PKCS11Card.java
@@ -54,6 +54,10 @@ public abstract class PKCS11Card extends SmartCard {
     protected abstract String getPKCS11ModuleName();
 
     protected abstract String getPKCS11ModulePath(int osFamily);
+    
+    protected String getPKCS11SlotIndex() {
+        return null;
+    }
 
     public KeyStore loadKeyStore(char[] pim) throws IOException, NoSuchAlgorithmException, CertificateException, KeyStoreException, NoSuchProviderException {
         int osFamily = getOsFamily();
@@ -70,7 +74,11 @@ public abstract class PKCS11Card extends SmartCard {
                 throw new KeyStoreException(message);
             } else {
                 String moduleName = this.getPKCS11ModuleName();
-                String moduleData = "name=" + moduleName + "\nlibrary=" + modulePath + "\nslotListIndex=1";
+                String moduleData = "name=" + moduleName + "\nlibrary=" + modulePath;
+                String slotIndex = this.getPKCS11SlotIndex();
+                if (slotIndex != null) {
+                    moduleData = moduleData + "\nslotListIndex=" + slotIndex;
+                }
                 Utils.logMessage("Loading PKCS11 module: " + moduleData);
                 Provider provider = new SunPKCS11(new ByteArrayInputStream(moduleData.getBytes()));
                 Utils.logMessage("Provider information:");

--- a/com/itsinbox/smartbox/model/PKCS11Gemalto.java
+++ b/com/itsinbox/smartbox/model/PKCS11Gemalto.java
@@ -38,4 +38,7 @@ public class PKCS11Gemalto extends PKCS11Card {
         }
     }
 
+    protected String getPKCS11SlotIndex() {
+        return "1";
+    }
 }


### PR DESCRIPTION
This PR fixes [issue 11](https://github.com/OpenSerbianEID/ePorezi/issues/11) by keeping the `slotIndex=1` moduleData suffix for the Halcom Gemalto PKCS11 module and dropping it for other PKCS11 modules (e.g. for MUP smart cards)