### PR TITLE
Add Github Actions workflow

### DIFF
--- a/.github/scripts/patch_info_plist.py
+++ b/.github/scripts/patch_info_plist.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from xml.dom import minidom
+
+main_path = 'out/ePorezi.app/Contents/Info.plist'
+main_doc = minidom.parse(main_path)
+
+append_str = '''
+<doc>
+    <key>CFBundleURLTypes</key>
+    <array>
+      <dict>
+        <key>CFBundleURLName</key>
+        <string>ePorezi</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+          <string>eporezi</string>
+        </array>
+      </dict>
+    </array>
+</doc>
+'''
+append_doc = minidom.parseString(append_str)
+
+for append_node in list(append_doc.childNodes[0].childNodes):
+	main_doc.childNodes[0].childNodes[1].appendChild(append_node)
+
+with open(main_path, 'w') as f:
+	f.write(main_doc.toxml())

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      
+      - name: Compile with Ant
+        run: ant compile
+
+      - name: Bundle with Ant
+        run: ant bundle
+
+      - name: Patch Info.plist
+        run: python3 .github/scripts/patch_info_plist.py
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: out-dir
+          path: out/**


### PR DESCRIPTION
This PR adds a Github Actions workflow to build the project and create downloadable artifacts.

It enables developers to build on Github's infrastructure without needing to set up a local development environment.