### PR TITLE
Java 17+ support

### DIFF
--- a/com/itsinbox/smartbox/SmartBox.java
+++ b/com/itsinbox/smartbox/SmartBox.java
@@ -3,6 +3,7 @@ package com.itsinbox.smartbox;
 import com.itsinbox.smartbox.gui.LoginFrame;
 import com.itsinbox.smartbox.gui.SettingsFrame;
 import com.itsinbox.smartbox.gui.SignXmlFrame;
+import com.itsinbox.smartbox.model.SmartCard;
 import com.itsinbox.smartbox.proxy.ProxyParams;
 import com.itsinbox.smartbox.proxy.ProxyUtils;
 import com.itsinbox.smartbox.utils.Utils;
@@ -104,18 +105,21 @@ public class SmartBox {
 
 
    public static void main(String[] args) {
+      Utils.logMessage("Java version: " + System.getProperty("java.version"));
       setLaf();
       ProxyUtils.init(SmartBox.PROXY_CONFIG_FILE);
       proxyParams = ProxyUtils.readProxySettings();
 
-
-      OSXAppleEventHelper.setOpenURIAppleEventHandler(new OpenUriAppleEventHandler() {
-         @Override
-         public void handleURI(URI url) {
-            loginFrame.dispose();
-            processUrl(url.toString());
-         }
-      });
+      int osFamily = SmartCard.getOsFamily();
+      if (osFamily == 4) {
+         OSXAppleEventHelper.setOpenURIAppleEventHandler(new OpenUriAppleEventHandler() {
+            @Override
+            public void handleURI(URI url) {
+               loginFrame.dispose();
+               processUrl(url.toString());
+            }
+         });
+      }
 
       showLogin((String) null);
    }


### PR DESCRIPTION
I've added some reflection stuff to get work java 8 and java 17+ with PKCS11.
I've tested it in linux and it works on java 8 and java 17+ but this change is require some testing on mac OS.

Also this change  in  theory opens possibility to change packaging from old jarbundler stuff to modern https://docs.oracle.com/en/java/javase/17/docs/specs/man/jpackage.html. 

PS:
PKCS11 docs for java 17: https://docs.oracle.com/en/java/javase/17/security/pkcs11-reference-guide1.html
PKCS11 docs for java8: https://docs.oracle.com/javase/8/docs/technotes/guides/security/p11guide.html

