### PR TITLE
Fix build and launch for newer JDK versions

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -12,7 +12,10 @@
 
     <target name="compile">
         <mkdir dir="./out/production/ePorezi"/>
-        <javac srcdir="." destdir="out/production/ePorezi" />
+        <javac srcdir="." destdir="out/production/ePorezi" source="1.8" target="1.8">
+            <compilerarg value="--add-exports=jdk.crypto.pkcs11/sun.security.pkcs11=ALL-UNNAMED"/>
+            <compilerarg value="--add-opens=jdk.crypto.pkcs11/sun.security.pkcs11=ALL-UNNAMED"/>
+        </javac>
     </target>
 
     <target name="bundle" depends="compile,jar" description="Create App Bundle">


### PR DESCRIPTION
I have `openjdk 17.0.7 2023-04-18` on MacOS, and I had the following issues:
- `package sun.security.pkcs11 is not visible` during compilation - was fixed by specifying `source="1.8" target="1.8"` in javac task
- `module jdk.crypto.cryptoki does not export sun.security.pkcs11 to unnamed module` at runtime - was fixed by compileargs to `javac` task

As far as I understand both are related to new Java 9 Modules. If there is a better way to fix this, feel free to reject the PR.